### PR TITLE
Proposal: add check selected function to 'check equals'

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,8 @@ Predefined keywords are:
 |                        | *object key*  | true / false  || Yes |
 | check readonly          |               || Checks if the object is readonly or not, applicable for input controls. ||
 |                        | *object key*  | true / false (string) || Yes |
+| check selected		 | 				 || Checks if the object is selected or not, suitable for checkboxes and radio buttons.||
+|						 |*object key*   | true / false (string) ||
 | clear local storage    |               |                 | Clears local storage. This keyword has no arguments. ||
 | delete cookies		 |               |                 | Deletes all application related cookies. This keyword has no arguments. ||
 | go back                |               |                 | Simulates pressing the **Back** browser button. |  |

--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ Predefined keywords are:
 | ---------------------- | ------------- | --------------- |------------ | ---------------------------- |
 | check equals           |               || Checks if the value of the object is exactly equal to the expected value. |            |
 |                        | *object key*  | *expected*      || Yes |
+|						 | 				 | selected / not selected (string)| check if the object is selected, useful for checkboxes and radio buttons|
 | check not equals       |               || Checks if the value of the object doesn't equal to the specified value. |            |
 |                        | *object key*  | *expected*      || Yes |
 | check matches          |               || Checks if the value of the object matches the expected regular expression. ||
@@ -303,8 +304,6 @@ Predefined keywords are:
 |                        | *object key*  | true / false  || Yes |
 | check readonly          |               || Checks if the object is readonly or not, applicable for input controls. ||
 |                        | *object key*  | true / false (string) || Yes |
-| check selected		 | 				 || Checks if the object is selected or not, suitable for checkboxes and radio buttons.||
-|						 |*object key*   | true / false (string) ||
 | clear local storage    |               |                 | Clears local storage. This keyword has no arguments. ||
 | delete cookies		 |               |                 | Deletes all application related cookies. This keyword has no arguments. ||
 | go back                |               |                 | Simulates pressing the **Back** browser button. |  |

--- a/keywords/index.coffee
+++ b/keywords/index.coffee
@@ -48,7 +48,12 @@ keywords =
       do -> ctx[key] = val
   'check equals': (args, ctx) ->
     for key, val of args
-      expect(get key).toEqual val, assertFailedMsg(ctx)
+      if val.toLowerCase() is "selected"
+        expect(testx.element(key).isSelected()).toBe true, "Assertion failure at element: #{key}"
+      else if val.toLowerCase() is "not selected"
+        expect(testx.element(key).isSelected()).toBe false, "Assertion failure at element: #{key}"
+      else
+        expect(get key).toEqual val, assertFailedMsg(ctx)
   'check not equals': (args, ctx) ->
     for key, val of args
       expect(get key).not.toEqual val, assertFailedMsg(ctx)
@@ -73,10 +78,6 @@ keywords =
     for key, val of args
       expectedValue = if val.toLowerCase() == 'true' then 'true' else null # Note: It returns 'true' as string, not as boolean
       expect(testx.element(key).getAttribute('readonly')).toBe expectedValue, assertFailedMsg(ctx)
-  'check selected': (args, ctx) ->
-    for key, val of args
-      expectedValue = val.toLowerCase() == 'true'
-      expect(testx.element(key).isSelected()).toBe expectedValue, "Assertion failure at element: #{key}"
   'set': (args) ->
     for key, val of args
       do -> set key, val

--- a/keywords/index.coffee
+++ b/keywords/index.coffee
@@ -73,6 +73,10 @@ keywords =
     for key, val of args
       expectedValue = if val.toLowerCase() == 'true' then 'true' else null # Note: It returns 'true' as string, not as boolean
       expect(testx.element(key).getAttribute('readonly')).toBe expectedValue, assertFailedMsg(ctx)
+  'check selected': (args, ctx) ->
+    for key, val of args
+      expectedValue = val.toLowerCase() == 'true'
+      expect(testx.element(key).isSelected()).toBe expectedValue, "Assertion failure at element: #{key}"
   'set': (args) ->
     for key, val of args
       do -> set key, val


### PR DESCRIPTION
Adding check selected function to the existing keyword 'check equals'. 
Pass 'selected' or 'not selected' as argument value. 
