### PR TITLE
add missing q dependency

### DIFF
--- a/keywords/index.coffee
+++ b/keywords/index.coffee
@@ -1,5 +1,6 @@
 path = require 'path'
 fs = require 'fs'
+q = require 'q'
 
 _ = require 'lodash'
 colors = require 'colors'

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "colors": "^1.1.2",
     "csv-parse": "^1.1.7",
     "lodash": "^4.16.4",
+    "q": "^1.5.1",
     "testx-xlsx-parser": "^1.0.1",
     "testx-yaml-parser": "^1.2.0"
   },


### PR DESCRIPTION
When using the `switch to` keyword I got the following error (with both `frame:` and `title:`):
```
  - Failed: q is not defined
```
The accompanying stack trace points to [lines 89-108 of testx's `keywords/index.coffee`](https://github.com/testxio/testx/blob/master/keywords/index.coffee#L89)

This is the only place that the mysterious `q` variable is used (or mentioned at all) that I could find.  
It appeared to be some sort of `promise`, and after some searching I thought that it might have something to do with [the `q` library on npmjs](https://www.npmjs.com/package/q). After installing that I get errors that actually make sense to me (e.g. `  - Failed: no such frame` because I haven't set the right locator yet), so I figured this solves it.


This diff just adds the `q` library to `package.json` (via `npm install --save q`) and includes it in the keywords file via `q = require 'q'`

Since there is only one place where this is used, it might be cleaner to do something different so that we no longer require the `q` library. Sadly, I don't have enough JavaScript-fu to do this myself.