### PR TITLE
Add missing clear function to the keywords

### DIFF
--- a/keywords/index.coffee
+++ b/keywords/index.coffee
@@ -136,3 +136,7 @@ keywords =
       keys = val.replace(/\[\w+\]/g, (match) ->
         protractor.Key[match.substring(1, match.length-1).toUpperCase()])
       browser.actions().sendKeys(keys).perform()
+  'clear': (args) ->
+    # Clear element(s)
+    for key, val of args
+      testx.element(key).clear()      


### PR DESCRIPTION
It clears the specified element(s) using the internal clear function. Very useful to clear fields like textarea (currently it is not easily cleared by using the existing functions, some workaround is needed).