### PR TITLE
add robustness feature disruptiveElement

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testx",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "A library for executing keyword driven tests with Protractor.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
in order to handle unpredictable disruptive elements like a loading/buffering indicator, set and wait now try their respective action and wait for the disruptive element to disappear.
The user can configure this behaviour with the parameter "disruptiveElement" which can contain a selector and a timeout