### PR TITLE
improve robustness of set with intercepted click

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testx",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "A library for executing keyword driven tests with Protractor.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/keywords/api.coffee
+++ b/src/keywords/api.coffee
@@ -20,7 +20,7 @@ set = (key, value) ->
   catch e
     if e.name == "WebDriverError" and e.message.includes("element click intercepted")
       await wait {objects: [key], timeout: testx.params.disruptiveElement?.timeout or "30s"}, cond.elementToBeClickable
-      await el.set value
+      set(key, value)
 
 wait = (args, condition = cond.visibilityOf) ->
   for obj in args.objects


### PR DESCRIPTION
set now calls itself after handling an intercepted click, so it can catch the same issue again if needed.